### PR TITLE
メモリ書き出しではなく、ファイル書き出し方式に戻す

### DIFF
--- a/archiver/archiver.go
+++ b/archiver/archiver.go
@@ -1,13 +1,19 @@
 package archiver
 
 import (
-	"bytes"
+	"time"
+	"os"
+	"fmt"
 
 	"github.com/shinofara/stand/archiver/compressor"
 	"github.com/shinofara/stand/config"
 
 	"github.com/uber-go/zap"
 	"golang.org/x/net/context"
+)
+
+const (
+	TimeFormat = "20060102150405"
 )
 
 type Archiver struct {
@@ -25,21 +31,51 @@ func New(ctx context.Context, cfg *config.Config) *Archiver {
 }
 
 //Archive generates a buffer of compressed files.
-func (a *Archiver) Archive() (*bytes.Buffer, error) {
+func (a *Archiver) Archive() (string, error) {
 	logger := a.ctx.Value("logger").(zap.Logger)
 
-
-	//ZIPファイル作成
-	buf := new(bytes.Buffer)
+	filepath :=a.makeCompressedFileName()
+	buf, err := os.Create(filepath)
+	if err != nil {
+		return "", err
+	}
+	defer buf.Close()
+	
 	c := compressor.New(a.ctx, a.cfg)
 
 	if err := c.Compress(buf); err != nil {
-		return nil, err
+		return "", err
 	}
+
+	info, err := buf.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	
 	logger.Info(
 		"Compression has been completed",
-		zap.Int("size", len(buf.Bytes())),
+		zap.Int64("size", info.Size()),
 	)
 
-	return buf, nil
+	return filepath, nil
 }
+
+func (a *Archiver) makeCompressedFileName() string {
+	timestamp := time.Now().Format(TimeFormat)
+
+	extention := "zip"
+switch a.cfg.CompressionConfig.Format {
+	case "tar":
+		extention = "tar.gz"
+	}
+
+	var filename string
+	if a.cfg.CompressionConfig.Prefix != "" {
+		filename = fmt.Sprintf("%s%s.%s", a.cfg.CompressionConfig.Prefix, timestamp, extention)
+	} else {
+		filename = fmt.Sprintf("%s.%s", timestamp, extention)
+	}
+	return fmt.Sprintf("/tmp/%s", filename)
+}
+

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -1,18 +1,10 @@
 package backup
 
 import (
-	"bytes"
-	"fmt"
-	"time"
-
 	"github.com/shinofara/stand/backup/location"
 	"github.com/shinofara/stand/config"
 
 	"golang.org/x/net/context"
-)
-
-const (
-	TimeFormat = "20060102150405"
 )
 
 //Backup manages all of the settings for backup
@@ -28,13 +20,12 @@ func New(ctx context.Context, cfg *config.Config) *Backup {
 	}
 }
 
-func (b *Backup) Exec(buf *bytes.Buffer) error {
+func (b *Backup) Exec(filepath string) error {
 	var loc location.Location
-	filename := b.makeCompressedFileName()
 
 	for _, storageCfg := range b.Config.StorageConfigs {
 		loc = location.New(&storageCfg)
-		if err := loc.Save(filename, buf); err != nil {
+		if err := loc.Save(filepath); err != nil {
 			return err
 		}
 
@@ -50,20 +41,3 @@ func (b *Backup) Exec(buf *bytes.Buffer) error {
 	return nil
 }
 
-func (b *Backup) makeCompressedFileName() string {
-	timestamp := time.Now().Format(TimeFormat)
-
-	extention := "zip"
-	switch b.Config.CompressionConfig.Format {
-	case "tar":
-		extention = "tar.gz"
-	}
-
-	var filename string
-	if b.Config.CompressionConfig.Prefix != "" {
-		filename = fmt.Sprintf("%s%s.%s", b.Config.CompressionConfig.Prefix, timestamp, extention)
-	} else {
-		filename = fmt.Sprintf("%s.%s", timestamp, extention)
-	}
-	return filename
-}

--- a/backup/location/interface.go
+++ b/backup/location/interface.go
@@ -1,12 +1,11 @@
 package location
 
 import (
-	"bytes"
 	"github.com/shinofara/stand/config"
 )
 
 type Location interface {
-	Save(filename string, buf *bytes.Buffer) error
+	Save(filename string) error
 	Clean() error
 }
 

--- a/backup/location/local.go
+++ b/backup/location/local.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"sort"
 	"fmt"
-	"bytes"
 )
 
 type Local struct {
@@ -19,18 +18,21 @@ func NewLocal(storageCfg *config.StorageConfig) *Local {
 	}
 }
 
-func (l *Local) Save(filename string, buf *bytes.Buffer) error {
+func (l *Local) Save(filename string) error {
 	if err := mkdir(l.storageCfg.Path); err != nil {
 		return err
 	}
 
-	storagePath := l.storageCfg.Path + "/" + filename
-	f, err := os.Create(storagePath)
+	//file mv
+	info, err := os.Stat(filename)
 	if err != nil {
 		return err
 	}
-	f.Write(buf.Bytes())
-	f.Close()
+	movePath := l.storageCfg.Path + "/" + info.Name()
+
+	if err := os.Rename(filename, movePath); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/backup/location/s3.go
+++ b/backup/location/s3.go
@@ -1,11 +1,11 @@
 package location
 
 import (
-	"bytes"
 	"fmt"
 	"path"
 	"regexp"
 	"sort"
+	"os"
 
 	"github.com/shinofara/stand/config"
 
@@ -41,11 +41,16 @@ func NewS3(storageCfg *config.StorageConfig) *S3 {
 	return s
 }
 
-func (s *S3) Save(filename string, buf *bytes.Buffer) error {
-	_, err := s.cli.PutObject(&s3.PutObjectInput{
+func (s *S3) Save(filename string) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	
+	_, err = s.cli.PutObject(&s3.PutObjectInput{
 		Bucket: aws.String(s.storageCfg.S3Config.BucketName),
-		Key:    aws.String(s.storageCfg.Path + "/" + filename),
-		Body:   bytes.NewReader(buf.Bytes()),
+		Key:    aws.String(s.storageCfg.Path + "/" + file.Name()),
+		Body:   file,
 	})
 	if err != nil {
 		return err

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -22,14 +22,14 @@ func New(ctx context.Context, cfg *config.Config) *Coordinator {
 
 func (c *Coordinator) Perform() error {
 	a := archiver.New(c.ctx, c.cfg)
-	buf, err := a.Archive()
+	filepath, err := a.Archive()
 
 	if err != nil {
 		return err
 	}
 
 	b := backup.New(c.ctx, c.cfg)
-	if err := b.Exec(buf); err != nil {
+	if err := b.Exec(filepath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#57 ある一定G数以上のファイルを生成できない問題

原因は、メモリにすべてを乗っけてしまっていた事で、環境メモリ以上のファイルを生成できずpanicとなってしまっていた。
その為、すべてメモリにのせる方式に変更したが、一部元に戻す

```
{"msg":"Compression has been completed","level":"info","ts":1468345634143274293,"fields":{"size":29412641132}}  
714.586 secs 
27G    20160713023520.zip 
```
