### PR TITLE
Use `filepath.Join` where possible, not `fmt.Sprintf` nor concatenation

### DIFF
--- a/archiver/archiver.go
+++ b/archiver/archiver.go
@@ -1,9 +1,10 @@
 package archiver
 
 import (
-	"time"
-	"os"
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/shinofara/stand/archiver/compressor"
 	"github.com/shinofara/stand/config"
@@ -76,6 +77,5 @@ switch a.cfg.CompressionConfig.Format {
 	} else {
 		filename = fmt.Sprintf("%s.%s", timestamp, extention)
 	}
-	return fmt.Sprintf("/tmp/%s", filename)
+	return filepath.Join(os.TempDir(), filename)
 }
-

--- a/backup/location/local.go
+++ b/backup/location/local.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"fmt"
 	"io"
+	"path/filepath"
 )
 
 type Local struct {
@@ -29,7 +30,7 @@ func (l *Local) Save(filename string) error {
 	if err != nil {
 		return err
 	}
-	movePath := l.storageCfg.Path + "/" + info.Name()
+	movePath := filepath.Join(l.storageCfg.Path, info.Name())
 
 	if err := copyFile(filename, movePath); err != nil {
 		return err
@@ -88,13 +89,13 @@ func (c *Clean) findMiddleware(path string, file *os.File) error {
 		return err
 	}
 
-	fullPath := fmt.Sprintf("%s/%s", c.storageCfg.Path, path)
-	
+	fullPath := filepath.Join(c.storageCfg.Path, path)
+
 	fInfo := File{
 		Info:     info,
 		Path:     path,
 		FullPath: fullPath}
-	
+
 	c.targets = append(c.targets, fInfo)
 	return nil
 }

--- a/find/find.go
+++ b/find/find.go
@@ -62,16 +62,16 @@ func (f *Find) Run() error {
 				if f.fileOnlyMode == FileOnlyMode {
 					return nil
 				}
-				
-				filePath = fmt.Sprintf("%s/", rel)
-				} else {
-					filePath = rel
-				}
-			
-			fullPath := fmt.Sprintf("%s/%s", f.targetDir, filePath)
+
+				filePath = rel + string(os.PathSeparator)
+			} else {
+				filePath = rel
+			}
+
+			fullPath := filepath.Join(f.targetDir, filePath)
 			addFile, _ := os.Open(fullPath)
 			defer addFile.Close()
-			
+
 			if err := f.callback(filePath, addFile); err != nil {
 				return err
 			}
@@ -107,8 +107,8 @@ func GetFiles(dir string) (FindFiles, error) {
 			return err
 		}
 
-		fullPath := fmt.Sprintf("%s/%s", dir, path)
-	
+		fullPath := filepath.Join(dir, path)
+
 		fInfo := File{
 			Info:     info,
 			Path:     path,


### PR DESCRIPTION
This change will luckily support Windows OS.
I've roughly tested local directory/file backups on WIndows 10 Build 14393.187 and it worked correctly.
